### PR TITLE
feat: define control packet protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,7 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 name = "rc-core"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.9.1",
  "defmt 1.0.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ panic-rtt-target = { version = "0.2.0", features = ["defmt"] }
 rtt-target = { version = "0.6.1", features = ["defmt"] }
 static_cell = "2.1.1"
 esp-ieee802154 = { git = "https://github.com/esp-rs/esp-ieee802154", default-features = false, features = ["esp32h2"] }
+bitflags = { version = "2", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,4 +9,5 @@ path = "src/lib.rs"
 
 [dependencies]
 defmt = { workspace = true }
+bitflags = { workspace = true }
 

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,18 @@
+# Core protocol
+
+The `ControlPacket` used for communication between transmitter and receiver has the
+following layout (all fields little endian):
+
+| bytes | field     | description                                     |
+|-------|-----------|-------------------------------------------------|
+| 0-1   | throttle  | `i16` throttle position                         |
+| 2-3   | steering  | `i16` steering position                         |
+| 4     | flags     | `u8` bitfield (bit0 = headlight)                |
+| 5     | checksum  | `u8` sum of bytes 0-4, wrapping on overflow     |
+
+Constants provided by the core crate:
+
+- `ControlPacket::RATE_HZ` — packets are sent at this rate.
+- `ControlPacket::THROTTLE_MIN`/`MAX` and `STEERING_MIN`/`MAX` — valid ranges.
+- `ControlFlags::HEADLIGHT` — bit flag for headlights.
+- `ControlPacket::FAILSAFE` — neutral packet used when communication is lost.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,26 +1,99 @@
 #![no_std]
 
+use bitflags::bitflags;
 use defmt::Format;
 
-/// Control data shared between transmitter and receiver
+/// Control data shared between transmitter and receiver.
+///
+/// Packet layout (little endian):
+///
+/// ```text
+/// 0-1  throttle  i16
+/// 2-3  steering  i16
+/// 4    flags     u8  (bit 0 = headlight)
+/// 5    checksum  u8  (sum of bytes 0-4, wrapping)
+/// ```
+bitflags! {
+    #[derive(Format)]
+    pub struct ControlFlags: u8 {
+        /// Headlight toggle.
+        const HEADLIGHT = 0x01;
+    }
+}
 #[derive(Clone, Copy, Format)]
 pub struct ControlPacket {
+    /// Throttle position.
     pub throttle: i16,
+    /// Steering position.
     pub steering: i16,
+    /// Miscellaneous buttons or toggles.
+    pub flags: ControlFlags,
+    /// Checksum of all preceding bytes.
+    pub checksum: u8,
 }
 
 impl ControlPacket {
-    pub const LEN: usize = 4;
+    /// Total size of a serialized packet in bytes.
+    pub const LEN: usize = 6;
 
+    /// Packets are sent at this rate.
+    pub const RATE_HZ: u32 = 50;
+    /// Minimum throttle value.
+    pub const THROTTLE_MIN: i16 = -1000;
+    /// Maximum throttle value.
+    pub const THROTTLE_MAX: i16 = 1000;
+    /// Minimum steering value.
+    pub const STEERING_MIN: i16 = -1000;
+    /// Maximum steering value.
+    pub const STEERING_MAX: i16 = 1000;
+    /// Neutral/failsafe packet.
+    pub const FAILSAFE: Self = Self {
+        throttle: 0,
+        steering: 0,
+        flags: ControlFlags::empty(),
+        checksum: 0,
+    };
+
+    /// Create a new packet and compute its checksum.
+    pub fn new(throttle: i16, steering: i16, flags: ControlFlags) -> Self {
+        let mut pkt = Self {
+            throttle,
+            steering,
+            flags,
+            checksum: 0,
+        };
+        pkt.checksum = pkt.calc_checksum();
+        pkt
+    }
+
+    fn calc_checksum(&self) -> u8 {
+        let t = self.throttle.to_le_bytes();
+        let s = self.steering.to_le_bytes();
+        t.iter()
+            .chain(s.iter())
+            .fold(self.flags.bits(), |acc, b| acc.wrapping_add(*b))
+    }
+
+    /// Serialize the packet to raw bytes.
     pub fn to_bytes(self) -> [u8; Self::LEN] {
         let t = self.throttle.to_le_bytes();
         let s = self.steering.to_le_bytes();
-        [t[0], t[1], s[0], s[1]]
+        let checksum = self.calc_checksum();
+        [t[0], t[1], s[0], s[1], self.flags.bits(), checksum]
     }
 
-    pub fn from_bytes(bytes: [u8; Self::LEN]) -> Self {
-        let throttle = i16::from_le_bytes([bytes[0], bytes[1]]);
-        let steering = i16::from_le_bytes([bytes[2], bytes[3]]);
-        Self { throttle, steering }
+    /// Deserialize a packet from raw bytes, validating the checksum.
+    pub fn from_bytes(bytes: [u8; Self::LEN]) -> Option<Self> {
+        let pkt = Self {
+            throttle: i16::from_le_bytes([bytes[0], bytes[1]]),
+            steering: i16::from_le_bytes([bytes[2], bytes[3]]),
+            flags: ControlFlags::from_bits_retain(bytes[4]),
+            checksum: bytes[5],
+        };
+        if pkt.calc_checksum() == pkt.checksum {
+            Some(pkt)
+        } else {
+            None
+        }
     }
 }

--- a/receiver/src/main.rs
+++ b/receiver/src/main.rs
@@ -11,10 +11,7 @@ use rc_core::ControlPacket;
 async fn main(_spawner: Spawner) {
     rtt_target::rtt_init_defmt!();
     info!("receiver boot");
-    let _ = ControlPacket {
-        throttle: 0,
-        steering: 0,
-    };
+    let _ = ControlPacket::FAILSAFE;
     loop {
         Timer::after(Duration::from_secs(1)).await;
     }

--- a/transmitter/src/main.rs
+++ b/transmitter/src/main.rs
@@ -11,10 +11,7 @@ use rc_core::ControlPacket;
 async fn main(_spawner: Spawner) {
     rtt_target::rtt_init_defmt!();
     info!("transmitter boot");
-    let _ = ControlPacket {
-        throttle: 0,
-        steering: 0,
-    };
+    let _ = ControlPacket::FAILSAFE;
     loop {
         Timer::after(Duration::from_secs(1)).await;
     }


### PR DESCRIPTION
## Summary
- extend ControlPacket with flags, checksum and helper methods
- add constants for packet rate, ranges and failsafe values
- document packet layout and update transmitter/receiver to reference failsafe
- model ControlPacket flags as bitflags for type-safe usage

## Testing
- `cargo check --target riscv32imac-unknown-none-elf` *(fails: RawRestoreStateInner is defined multiple times in critical-section crate)*

------
https://chatgpt.com/codex/tasks/task_e_68aa41de62c48331a7ddff4e3b12d3fb