### PR TITLE
Integrate IEEE802.15.4 radio transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "esp-alloc"
+version = "0.8.0"
+source = "git+https://github.com/esp-rs/esp-hal#522ff0bb7322e8aa57f791a14b2fd5da12e76790"
+dependencies = [
+ "allocator-api2",
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "enumset",
+ "linked_list_allocator",
+]
+
+[[package]]
 name = "esp-bootloader-esp-idf"
 version = "0.2.0"
 source = "git+https://github.com/esp-rs/esp-hal#522ff0bb7322e8aa57f791a14b2fd5da12e76790"
@@ -943,6 +956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked_list_allocator"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
+
+[[package]]
 name = "litrs"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1158,7 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
  "esp-hal",
+ "esp-radio",
 ]
 
 [[package]]
@@ -1148,6 +1168,7 @@ dependencies = [
  "critical-section",
  "defmt 1.0.1",
  "embassy-executor",
+ "esp-alloc",
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-hal-embassy",
@@ -1390,6 +1411,7 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-executor",
  "embassy-futures",
+ "esp-alloc",
  "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-hal-embassy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ static_cell = "2.1.1"
 esp-radio = { git = "https://github.com/esp-rs/esp-hal", package = "esp-radio", default-features = false, features=["ieee802154", "esp32h2", "unstable"] }
 bitflags = { version = "2", default-features = false }
 embassy-futures = "0.1.1"
+esp-alloc = { git = "https://github.com/esp-rs/esp-hal", package = "esp-alloc" }
 
 # [patch.crates-io]
 # esp-wifi-sys = { git = "https://github.com/stestagg/esp-wifi-sys", features=["esp32h2"]  }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,4 +12,5 @@ defmt = { workspace = true }
 bitflags = { workspace = true }
 esp-hal = { workspace = true }
 embassy-futures = { workspace = true }
+esp-radio = { workspace = true }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,11 +27,9 @@ bitflags! {
 
 impl defmt::Format for ControlFlags {
     fn format(&self, f: defmt::Formatter) {
-        let mut have_one = false;
         defmt::write!(f, "ControlFlags(");
         if self.contains(Self::HEADLIGHT) {
             defmt::write!(f, "HEADLIGHT");
-            have_one = true;
         }
         defmt::write!(f, ")");
     }

--- a/core/src/radio.rs
+++ b/core/src/radio.rs
@@ -1,6 +1,6 @@
 use embassy_futures::yield_now;
-use esp_hal::peripherals::{IEEE802154, RADIO_CLK};
-use esp_ieee802154::{Config, Error, Ieee802154};
+use esp_hal::peripherals::IEEE802154;
+use esp_radio::ieee802154::{Config, Error, Ieee802154};
 
 use crate::ControlPacket;
 
@@ -12,8 +12,8 @@ pub struct Radio<'a> {
 
 impl<'a> Radio<'a> {
     /// Initialise the radio with default configuration and start receiving.
-    pub fn new(radio: IEEE802154, radio_clocks: &mut RADIO_CLK) -> Self {
-        let mut inner = Ieee802154::new(radio, radio_clocks);
+    pub fn new(radio: IEEE802154<'a>) -> Self {
+        let mut inner = Ieee802154::new(radio);
         inner.set_config(Config::default());
         inner.start_receive();
         Self { inner }
@@ -29,7 +29,7 @@ impl<'a> Radio<'a> {
     /// Receive the next valid [`ControlPacket`].
     pub async fn receive(&mut self) -> ControlPacket {
         loop {
-            if let Some(raw) = self.inner.get_raw_received() {
+            if let Some(raw) = self.inner.raw_received() {
                 let len = raw.data[0] as usize;
                 if len >= ControlPacket::LEN {
                     let mut buf = [0u8; ControlPacket::LEN];

--- a/receiver/Cargo.toml
+++ b/receiver/Cargo.toml
@@ -16,3 +16,4 @@ panic-rtt-target = { workspace = true }
 rtt-target = { workspace = true }
 static_cell = { workspace = true }
 esp-radio = { workspace = true }
+esp-alloc = { workspace = true }

--- a/receiver/src/main.rs
+++ b/receiver/src/main.rs
@@ -3,19 +3,19 @@
 
 use defmt::info;
 use embassy_executor::Spawner;
-use esp_hal::peripherals::Peripherals;
+use esp_alloc as _;
 use panic_rtt_target as _;
-use rc_core::{radio::Radio, ControlPacket};
+use rc_core::radio::Radio;
 
 #[esp_hal_embassy::main]
 async fn main(_spawner: Spawner) {
     rtt_target::rtt_init_defmt!();
     info!("receiver boot");
 
-    let mut peripherals = Peripherals::take();
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+    esp_alloc::heap_allocator!(size: 24 * 1024);
     let ieee = peripherals.IEEE802154;
-    let mut radio_clk = peripherals.RADIO_CLK;
-    let mut radio = Radio::new(ieee, &mut radio_clk);
+    let mut radio = Radio::new(ieee);
 
     loop {
         let pkt = radio.receive().await;

--- a/transmitter/Cargo.toml
+++ b/transmitter/Cargo.toml
@@ -17,3 +17,4 @@ rtt-target = { workspace = true }
 static_cell = { workspace = true }
 embassy-futures = { workspace = true }
 esp-radio = { workspace = true }
+esp-alloc = { workspace = true }

--- a/transmitter/src/main.rs
+++ b/transmitter/src/main.rs
@@ -4,7 +4,7 @@
 use defmt::info;
 use embassy_executor::Spawner;
 use embassy_futures::yield_now;
-use esp_hal::peripherals::Peripherals;
+use esp_alloc as _;
 use panic_rtt_target as _;
 use rc_core::{radio::Radio, ControlPacket};
 
@@ -13,10 +13,10 @@ async fn main(_spawner: Spawner) {
     rtt_target::rtt_init_defmt!();
     info!("transmitter boot");
 
-    let mut peripherals = Peripherals::take();
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+    esp_alloc::heap_allocator!(size: 24 * 1024);
     let ieee = peripherals.IEEE802154;
-    let mut radio_clk = peripherals.RADIO_CLK;
-    let mut radio = Radio::new(ieee, &mut radio_clk);
+    let mut radio = Radio::new(ieee);
 
     let pkt = ControlPacket::FAILSAFE;
 


### PR DESCRIPTION
## Summary
- use esp-radio for IEEE802.15.4 communication
- initialize heap allocator with esp-alloc in binaries
- switch to esp-hal init API

## Testing
- `cargo check --target riscv32imac-unknown-none-elf`

------
https://chatgpt.com/codex/tasks/task_e_68aa57e3a8d4833190643a208767d383