### PR TITLE
Add CI workflow for riscv32 check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rust-src
+          target: riscv32imac-unknown-none-elf
+          override: true
+      - name: Cargo check
+        run: cargo check --target riscv32imac-unknown-none-elf


### PR DESCRIPTION
## Summary
- run cargo check for esp-h2 target in GitHub Actions

## Testing
- `cargo check --target riscv32imac-unknown-none-elf`


------
https://chatgpt.com/codex/tasks/task_e_68aafbf3c210833192b0df47a98036aa