### PR TITLE
Build ESP32-H2 binaries in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rust-src
+          target: riscv32imac-unknown-none-elf
+          override: true
+      - name: Cargo build
+        run: cargo build --bins --target riscv32imac-unknown-none-elf


### PR DESCRIPTION
## Summary
- run `cargo build` for ESP32-H2 target in GitHub Actions to catch linker issues

## Testing
- `cargo build --bins --target riscv32imac-unknown-none-elf`
- `cargo check --target riscv32imac-unknown-none-elf`


------
https://chatgpt.com/codex/tasks/task_e_68aafbf3c210833192b0df47a98036aa